### PR TITLE
Pin Emurgo's packages.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "12.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@emurgo/cardano-serialization-lib-browser": "^12.0.0-beta.2",
-        "@emurgo/cardano-serialization-lib-nodejs": "^12.0.0-beta.2",
+        "@emurgo/cardano-serialization-lib-browser": "12.0.0-beta.2",
+        "@emurgo/cardano-serialization-lib-nodejs": "12.0.0-beta.2",
         "@mlabs-haskell/csl-gc-wrapper": "^1.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "klntsky",
   "license": "ISC",
   "dependencies": {
-    "@emurgo/cardano-serialization-lib-browser": "^12.0.0-beta.2",
-    "@emurgo/cardano-serialization-lib-nodejs": "^12.0.0-beta.2",
+    "@emurgo/cardano-serialization-lib-browser": "12.0.0-beta.2",
+    "@emurgo/cardano-serialization-lib-nodejs": "12.0.0-beta.2",
     "@mlabs-haskell/csl-gc-wrapper": "^1.0.2"
   }
 }


### PR DESCRIPTION
This is done to avoid mismatch versions of packages the rely on CSL.